### PR TITLE
fix: remove opinionated event styling

### DIFF
--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -101,8 +101,6 @@ export const useCalendarStyles = () => {
         },
         event: {
           backgroundColor: colors.event,
-          justifyContent: 'center',
-          paddingLeft: spacing(1),
           position: 'absolute',
           width: '100%',
         },


### PR DESCRIPTION
## Motivation
These two styles for the "event content" are relatively opinionated -- I think we should remove them. In particular, the `justifyContent: 'center'` makes it difficult to match our designs, which justify the event content to the top of the event.
<!-- Describe _why_ this change should merge. -->

## Screenshots

<!-- Add video recordings of any new UI behavior. If there is no new behavior, just write "N/A". -->
