### PR TITLE
fix!: remove spacing function in favor of a single hard-coded style

### DIFF
--- a/src/Calendar.tsx
+++ b/src/Calendar.tsx
@@ -26,8 +26,6 @@ export type CalendarEvent = TimeSlot & {
 export type CalendarStylesProps = {
   /** Color overrides to use within the calendar. */
   colors?: Partial<CalendarColors>;
-  /** A spacing function to use within the calendar. */
-  spacing?: (unit: number) => number;
 };
 
 export type CalendarProps = {
@@ -132,9 +130,9 @@ const Calendar: React.FC<CalendarProps> = (props) => {
 
 const WithContextProps: React.FC<
   CalendarProps & CalendarStylesProps & CalendarRenderersProps
-> = ({ colors, spacing, renderers, ...props }) => {
+> = ({ colors, renderers, ...props }) => {
   return (
-    <CalendarStylesProvider colors={colors} spacing={spacing}>
+    <CalendarStylesProvider colors={colors}>
       <CalendarRenderersProvider renderers={renderers}>
         <Calendar {...props} />
       </CalendarRenderersProvider>

--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -34,11 +34,8 @@ const DEFAULT_COLORS: CalendarColors = {
   separator: 'gray',
 };
 
-const DEFAULT_SPACING = (unit: number) => unit * 8;
-
 type InternalCalendarStylesContextValue = {
   colors: CalendarColors;
-  spacing: (unit: number) => number;
 };
 
 /**
@@ -48,27 +45,21 @@ type InternalCalendarStylesContextValue = {
 const CalendarStylesContext =
   React.createContext<InternalCalendarStylesContextValue>({
     colors: DEFAULT_COLORS,
-    spacing: DEFAULT_SPACING,
   });
 
 export type CalendarStylesProviderProps = {
   children?: React.ReactNode;
   colors?: Partial<CalendarColors>;
-  spacing?: (unit: number) => number;
 };
 
 export const CalendarStylesProvider: React.FC<CalendarStylesProviderProps> = ({
   children,
   colors = {},
-  spacing,
 }) => {
   const value = React.useMemo(
-    () => ({
-      colors: merge(DEFAULT_COLORS, colors),
-      spacing: spacing ?? DEFAULT_SPACING,
-    }),
+    () => ({ colors: merge(DEFAULT_COLORS, colors) }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [...Object.values(colors), spacing]
+    [...Object.values(colors)]
   );
 
   return (
@@ -79,7 +70,7 @@ export const CalendarStylesProvider: React.FC<CalendarStylesProviderProps> = ({
 };
 
 export const useCalendarStyles = () => {
-  const { colors, spacing } = React.useContext(CalendarStylesContext);
+  const { colors } = React.useContext(CalendarStylesContext);
 
   return React.useMemo(
     () => {
@@ -110,7 +101,7 @@ export const useCalendarStyles = () => {
         },
         font: {
           marginTop: -6, // 1 from time height style and 5 from half the fontSize
-          paddingRight: spacing(2),
+          paddingRight: 10,
           textAlign: 'right',
         },
         flex: {


### PR DESCRIPTION
**Note**: This PR depends on #16.

## Motivation
After #16, there is only one remaining usage of the `spacing(...)` function. This made me think it might be worth just removing entirely, since we can use `renderers` to completely override that usage anyway.

One less prop seems like a win.

## Screenshots

<!-- Add video recordings of any new UI behavior. If there is no new behavior, just write "N/A". -->
