### PR TITLE
fix: use unique, human-readable testids for time slots to allow for testing

### DIFF
--- a/src/TimeSlot.test.tsx
+++ b/src/TimeSlot.test.tsx
@@ -14,9 +14,9 @@ describe('TimeSlot', () => {
   it('renders TimeSlot without onGridPress', () => {
     const view = render(<TimeSlot time={{ ...baseTime, time: '11:45 AM' }} />);
 
-    expect(view.queryByTestId('time slot')).toBeTruthy();
+    expect(view.queryByTestId('11:45 AM')).toBeTruthy();
 
-    expect(view.getByTestId('time slot')).not.toBeDisabled();
+    expect(view.getByTestId('11:45 AM')).not.toBeDisabled();
   });
 
   it('renders TimeSlot with onGridPress but disabled', () => {
@@ -28,10 +28,10 @@ describe('TimeSlot', () => {
       />
     );
 
-    expect(view.queryByTestId('time slot')).toBeTruthy();
-    expect(view.getByTestId('time slot')).toBeDisabled();
+    expect(view.queryByTestId('11:45 AM')).toBeTruthy();
+    expect(view.getByTestId('11:45 AM')).toBeDisabled();
 
-    fireEvent.press(view.getByTestId('time slot'));
+    fireEvent.press(view.getByTestId('11:45 AM'));
 
     expect(onGridPressMock).not.toHaveBeenCalled();
   });
@@ -45,9 +45,9 @@ describe('TimeSlot', () => {
       />
     );
 
-    expect(view.queryByTestId('time slot')).toBeTruthy();
+    expect(view.queryByTestId('11:45 AM')).toBeTruthy();
 
-    fireEvent.press(view.getByTestId('time slot'));
+    fireEvent.press(view.getByTestId('11:45 AM'));
 
     expect(onGridPressMock).toHaveBeenCalledWith(
       undefined,
@@ -64,9 +64,9 @@ describe('TimeSlot', () => {
       />
     );
 
-    expect(view.queryByTestId('time slot')).toBeTruthy();
+    expect(view.queryByTestId('12:00 PM')).toBeTruthy();
 
-    fireEvent.press(view.getByTestId('time slot'));
+    fireEvent.press(view.getByTestId('12:00 PM'));
 
     expect(onGridPressMock).toHaveBeenCalledWith(
       undefined,
@@ -83,9 +83,9 @@ describe('TimeSlot', () => {
       />
     );
 
-    expect(view.queryByTestId('time slot')).toBeTruthy();
+    expect(view.queryByTestId('3:15 PM')).toBeTruthy();
 
-    fireEvent.press(view.getByTestId('time slot'));
+    fireEvent.press(view.getByTestId('3:15 PM'));
 
     expect(onGridPressMock).toHaveBeenCalledWith(
       undefined,

--- a/src/TimeSlot.tsx
+++ b/src/TimeSlot.tsx
@@ -41,7 +41,7 @@ export const TimeSlot: React.FC<TimeSlotProps> = (props) => {
         time.disabled ? styles.disabled : styles.enabled,
         { height: time.height },
       ]}
-      testID="time slot"
+      testID={time.time === 'Noon' ? '12:00 PM' : time.time}
     />
   );
 };


### PR DESCRIPTION
## Motivation
Adding unique test ids to each time slot will help us write great tests around this component!

## Screenshots

<!-- Add video recordings of any new UI behavior. If there is no new behavior, just write "N/A". -->
