### PR TITLE
fix: hide overflow content from events

### DIFF
--- a/demo-app/App.tsx
+++ b/demo-app/App.tsx
@@ -61,6 +61,12 @@ const InteractiveCalendar = () => {
       endDate: new Date(2022, 8, 7, 13, 0),
       title: 'Event 2',
     },
+    {
+      id: 'id-3',
+      startDate: new Date(2022, 8, 7, 14, 30),
+      endDate: new Date(2022, 8, 7, 14, 45),
+      title: 'Event 3',
+    },
   ]);
 
   return (

--- a/src/styles.tsx
+++ b/src/styles.tsx
@@ -94,6 +94,7 @@ export const useCalendarStyles = () => {
           backgroundColor: colors.event,
           position: 'absolute',
           width: '100%',
+          overflow: 'hidden',
         },
         separator: {
           backgroundColor: colors.separator,


### PR DESCRIPTION
## Motivation
By default, we should prevent content from overflowing off of the events.
<!-- Describe _why_ this change should merge. -->

## Screenshots
| Before | After |
| - | - |
| <img width="1539" alt="Screen Shot 2022-09-23 at 11 35 09 AM" src="https://user-images.githubusercontent.com/14932834/191998993-d26c551a-f07e-47fc-a393-4eb8b06648ea.png"> | <img width="1527" alt="Screen Shot 2022-09-23 at 11 35 33 AM" src="https://user-images.githubusercontent.com/14932834/191999020-4ddd8bde-91d3-48ea-bec1-bdb37bc16f1c.png"> |
