### PR TITLE
Remove codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @aecorredor @jkdowdle @virdesai @swain


### PR DESCRIPTION
## Motivation
I don't think we need a CODEOWNERS file here anymore. Plus, removing this will allow `loscm` to auto-merge dependabot PRs.
<!-- Describe _why_ this change should merge. -->

## Screenshots

<!-- Add video recordings of any new UI behavior. If there is no new behavior, just write "N/A". -->
